### PR TITLE
fix: remove other CT industries except for cement

### DIFF
--- a/cc-mage/transformers/locode_transformation.sql
+++ b/cc-mage/transformers/locode_transformation.sql
@@ -27,6 +27,8 @@ WITH emissions_ct AS (
     FROM raw_data.ippu_ct_staging a
     LEFT JOIN raw_data.country_codes b 
 	ON a.actor_id = b.iso3_code
+    -- AE: we are only loading cement for now since it has processing and fuel combustion seperated
+    WHERE a.industry = 'cement'
 	GROUP BY actor_id, unit_denominator, emissions_units, gpc_refno, country_code, emissions_year, gas_name, activity_name, activity_subcategory_type, ST_MakePoint(lon, lat)
 )
 SELECT  


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove all Carbon Trading (CT) industries except for cement from the data processing logic in `locode_transformation.sql`.

### Why are these changes being made?

This change is being made to focus the data processing solely on the cement industry, as it has its processing and fuel combustion activities separated, allowing for more accurate and relevant data handling at the current stage. This refines the scope of the analysis to ensure that the data is manageable and accurately reflects the industry's specific operations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->