### PR TITLE
feat: agentic engineering foundation (rules, skills, AGENTS, runbook)

### DIFF
--- a/.cursor/rules/dataset-review-catalog.mdc
+++ b/.cursor/rules/dataset-review-catalog.mdc
@@ -1,0 +1,68 @@
+---
+description: dataset-review/ and catalog/index.yaml conventions — releases, status fields, completeness.
+globs: dataset-review/**/*.yaml,dataset-review/**/*.yml,dataset-review/**/*.md
+alwaysApply: false
+---
+
+# Dataset Review & Catalog
+
+`dataset-review/` is **the registry**. Every dataset that touches our pipelines exists here, with a per-release folder and a row in `catalog/index.yaml`.
+
+## Per-publisher layout
+
+```
+dataset-review/
+├── catalog/index.yaml                       # registry, see below
+├── collections/collection.yaml              # thematic groupings
+└── reviews/<publisher>/<dataset-id>/
+    ├── README.md                             # human-readable summary
+    └── releases/<version>/
+        ├── review.yaml                       # structured per-release review
+        └── sample/                            # optional sample data
+```
+
+## `catalog/index.yaml` — required fields per release
+
+```yaml
+datasets:
+  - id: <publisher>-<dataset-slug>
+    name: Human readable name
+    publisher: <publisher_short_name>
+    coverage: { type: country|global|city, value: <value> }
+    themes: [climate, energy, ...]
+    update_frequency: annual|quarterly|monthly|adhoc
+    priority: high|medium|low
+    releases:
+      - version: '2026'
+        production_approved: false
+        is_latest: true
+        license: { spdx: '...', url: '...' }
+        pipeline_name: ghgi_<...>           # MUST be present once production_approved=true
+        data_quality:                        # MUST be present once production_approved=true
+          layer_2_passed: true
+          layer_3_passed: pending
+          notes: '...'
+        urls: { source: '...', methodology: '...' }
+```
+
+**Hard rule:** `production_approved: true` → `pipeline_name` and `data_quality` MUST be filled. CI / agents flag this drift.
+
+## When you add a new release
+
+Use the **`add-dataset-release`** skill.
+
+## When you add a new publisher / dataset
+
+Use the **`add-publisher`** skill.
+
+## `review.yaml` per release
+
+Structured per-release notes covering: source format, themes, key attributes, integration recommendation (which pipeline pattern), production-readiness (`production_ready: yes|pending_validation|no`).
+
+## Old releases — preserve
+
+Do **not** delete old `releases/<v>/` folders. When updating, add a new `<v+1>` alongside and flip `is_latest`.
+
+## Catalog completeness check
+
+Run the `definition-of-done-check` skill to validate `catalog/index.yaml` against the rules above before opening a PR.

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1,0 +1,13 @@
+---
+description: General coding standards — simple, maintainable, data-pipeline-aware code.
+alwaysApply: true
+---
+
+# General Rules
+
+- Keep code simple and easy to maintain.
+- Do not over-engineer. Prefer a Mage block + SQL over a Python framework.
+- Comments / docstrings everywhere code is non-trivial. Especially for data-loaders that depend on a particular source format.
+- Prefer **intent / why** comments over line-by-line narration.
+- Do not introduce backwards-compat shims or extra abstraction layers unless a real second use case justifies them.
+- Reproducibility > cleverness. A pipeline that runs once correctly is more valuable than a clever helper used nowhere else.

--- a/.cursor/rules/git-conventions.mdc
+++ b/.cursor/rules/git-conventions.mdc
@@ -52,5 +52,5 @@ Use the cross-repo `pull-request-standards` skill (mirrored in `.cursor/skills/`
 ## Merge policy
 
 - **Pipelines, catalog, knowledge-base, code** — any tech-team member can merge after standard review (≥ 1 approval, CI green).
-- **Agentic + standards foundation** (`AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, `docs/agent-runbook.md`) — **CTO is the curator**. PRs touching these need CTO sign-off; after approval, anyone in the tech team merges.
+- **Agentic + standards foundation** (`AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, `docs/agent-runbook.md`) — curated by the **core engineering team**. PRs touching these need core-team sign-off; after approval, anyone in the tech team merges.
 - **Agents** push branches and stop. They never merge their own PRs and don't open PRs unless explicitly told.

--- a/.cursor/rules/git-conventions.mdc
+++ b/.cursor/rules/git-conventions.mdc
@@ -1,0 +1,56 @@
+---
+description: Branch naming, commit format, PR text, and base-branch policy for global-data.
+alwaysApply: true
+---
+
+# Git Conventions — global-data
+
+## Base branch
+
+**`develop`**. CI builds/publishes the Mage Docker image on push to `develop`.
+
+## Branch naming
+
+```
+<author>/<scope>-<slug>           # e.g. mfonsecaoef/feat-eurostat-pipeline
+feat/<TICKET>-<slug>              # ticket-driven feature
+fix/<TICKET>-<slug>               # ticket-driven bugfix
+chore/<slug>                      # housekeeping
+agent/<slug>                      # Cursor-agent-driven
+agentic-coder/<slug>              # autonomous agentic-coder run
+```
+
+`<slug>` is kebab-case, ≤ 6 words.
+
+## Commit messages — Conventional Commits
+
+```
+<type>(<scope>): <imperative summary>     # ≤72 chars
+
+<body — explain WHY, wrap at 72>
+
+<footer — Refs: ON-####>
+```
+
+Allowed `<type>`: `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`.
+
+Recommended `<scope>`: `mage`, `pipeline`, `catalog`, `review`, `kb`, `standards`, `docker`, `ci`.
+
+Examples:
+
+```
+feat(pipeline): add ghgi_ippu_climatetrace v2026 release
+fix(catalog): set production_approved=false for stale wb_v1
+chore(docker): bump mage-ai base image
+docs(standards): clarify data-quality layer 2 expectations
+```
+
+## PR titles & bodies
+
+Use the cross-repo `pull-request-standards` skill (mirrored in `.cursor/skills/`).
+
+## Merge policy
+
+- **Pipelines, catalog, knowledge-base, code** — any tech-team member can merge after standard review (≥ 1 approval, CI green).
+- **Agentic + standards foundation** (`AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, `docs/agent-runbook.md`) — **CTO is the curator**. PRs touching these need CTO sign-off; after approval, anyone in the tech team merges.
+- **Agents** push branches and stop. They never merge their own PRs and don't open PRs unless explicitly told.

--- a/.cursor/rules/identity-keys.mdc
+++ b/.cursor/rules/identity-keys.mdc
@@ -1,0 +1,41 @@
+---
+description: Identity / FK rules — locode, actor_id, datasource_name, gpc_reference_number.
+alwaysApply: true
+---
+
+# Identity Keys
+
+This is the #1 source of bugs in queries and Python transforms. Get this right.
+
+| Identifier | Definition | Where it appears |
+|------------|------------|------------------|
+| `actor_id` | UN/LOCODE city code (e.g. `BR SAO`). Same value as `locode`. | `modelled.emissions`, `modelled.emissions_factor` |
+| `locode` | Same as `actor_id`. The city's primary key. | `modelled.city_polygon` |
+| `city_id` | **GeoHash of the city centroid** — NOT a primary key. **Never** use as a join key. | `modelled.city_polygon`, some staging tables |
+| `datasource_name` | Short string key linking emissions back to a publisher. **Exact-match FK** to `publisher_datasource.datasource_name`. | All `modelled.*` tables |
+| `gpc_reference_number` | GPC sector reference, e.g. `II.1.1`. | `modelled.emissions`, `modelled.ghgi_methodology` |
+| `gpcmethod_id` | UUID linking emission → activity_subcategory → ghgi_methodology. | FK across emissions tables |
+
+## Hard rules
+
+- **Joins on city** use `actor_id` or `locode` — never `city_id`.
+- **`datasource_name`** must match an existing row in `publisher_datasource`. Case- and whitespace-sensitive. If the publisher row is missing, add it in the **same PR** as the data ingestion.
+- **`gpc_reference_number`** is a string with embedded dots (`I.1.1`). Don't normalise away the dots.
+- **`gpcmethod_id`** is a UUID generated server-side, not from the source. Do not invent UUIDs in transforms — use the methodology lookup.
+
+## Common mistakes to flag in PR review
+
+- `JOIN city_polygon ON city_polygon.city_id = emissions.actor_id` — wrong; uses geohash instead of LOCODE.
+- `WHERE datasource_name LIKE 'edgar%'` — fragile; `datasource_name` is exact-match. Use `=`.
+- `actor_id` formatted differently across pipelines (e.g. with/without space). Use the canonical form (`'BR SAO'`).
+- Inserting into `modelled.emissions` without first ensuring the matching `publisher_datasource` row exists.
+
+## Looking it up at runtime
+
+```sql
+-- Verify a datasource_name exists
+SELECT 1 FROM publisher_datasource WHERE datasource_name = 'climatetrace_v2025';
+
+-- Look up a city by either key
+SELECT * FROM modelled.city_polygon WHERE locode = 'BR SAO';
+```

--- a/.cursor/rules/mage-blocks-python.mdc
+++ b/.cursor/rules/mage-blocks-python.mdc
@@ -1,0 +1,103 @@
+---
+description: Python block conventions — data_loader, transformer, data_exporter shapes.
+globs: cc-mage/**/data_loaders/**/*.py,cc-mage/**/transformers/**/*.py,cc-mage/**/data_exporters/**/*.py
+alwaysApply: false
+---
+
+# Python Block Conventions
+
+## Block shape
+
+```python
+"""<pipeline_name> / <block_name>
+
+Brief: what this block does in 1 sentence.
+
+Inputs:  pandas.DataFrame from <upstream_block>
+Outputs: pandas.DataFrame consumed by <downstream_block>
+"""
+
+from typing import Optional
+import pandas as pd
+
+if 'transformer' not in globals():
+    from mage_ai.data_preparation.decorators import transformer
+if 'test' not in globals():
+    from mage_ai.data_preparation.decorators import test
+
+
+@transformer
+def transform(df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
+    """Transform <input> into <output>.
+
+    See the docstring at top of file for full input/output spec.
+    """
+    # ... pure DataFrame logic; no I/O here
+
+    return df
+
+
+@test
+def test_output_schema(output, *args) -> None:
+    """Output must have the canonical columns and a positive row count."""
+    expected = {"locode", "year", "gas", "value", "gpc_ref"}
+    missing = expected - set(output.columns)
+    assert not missing, f"missing columns: {missing}"
+    assert len(output) > 0, "empty output — upstream filter too aggressive?"
+```
+
+## I/O is data_loader / data_exporter only
+
+- `transformer` blocks must be **pure**: in → out, no S3, no DB, no `os.environ` reads.
+- I/O happens in `data_loader` (read) and `data_exporter` (write) blocks. They are the only blocks allowed to import `boto3` or `mage_ai.io.*`.
+
+## Tests are mandatory beyond `assert output is not None`
+
+The default Mage `@test` template asserts non-null. **That is not enough.** At minimum:
+
+- Schema check: column names + dtypes match expected.
+- Row count > 0 (or document why empty is allowed).
+- Primary-key-ish uniqueness check: e.g. `(locode, year, gas)` is unique.
+- Identity check: `actor_id` values look like UN/LOCODE strings (regex `^[A-Z]{2} [A-Z0-9]{3}$`).
+- Plausibility: numeric ranges (e.g. emissions are non-negative).
+
+These are **Layer 2** checks per `engineering-standards/data-quality-and-validation.md`.
+
+## Variables come from kwargs
+
+`metadata.yaml.variables` are passed via `kwargs`:
+
+```python
+@data_loader
+def load(*args, **kwargs) -> pd.DataFrame:
+    bucket = kwargs.get("bucket_name", "test-global-api")
+    source_path = kwargs["source_path"]
+    # ...
+```
+
+Never read from `os.environ` directly inside a block — it breaks when running through Mage's UI.
+
+## boto3 etiquette
+
+- One client per block (`s3 = boto3.client("s3")` once at top of function).
+- Use `paginator` for listings.
+- For large files, use `get_object()['Body'].read()` only if the file is small. Otherwise stream to disk and read with pandas.
+
+## Logging
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+logger.info("loaded %d rows from %s", len(df), source_path)
+```
+
+Don't `print()` for production-meaningful logs.
+
+## Anti-patterns
+
+- `pd.read_csv(s3_url)` with no error handling.
+- Mutating an upstream DataFrame in place — make a `.copy()` first.
+- `assert output is not None` as the only test.
+- Reading credentials from anywhere other than the documented config layer.
+- Long Jupyter-style "exploration" left in the block code.

--- a/.cursor/rules/mage-blocks-sql.mdc
+++ b/.cursor/rules/mage-blocks-sql.mdc
@@ -1,0 +1,84 @@
+---
+description: SQL block conventions — UPSERTs to modelled.*, REPLACE to staging, idempotency.
+globs: cc-mage/**/transformers/**/*.sql,cc-mage/**/data_exporters/**/*.sql
+alwaysApply: false
+---
+
+# SQL Block Conventions
+
+## Write policy by stage
+
+| Target schema | `export_write_policy` | Pattern |
+|---------------|----------------------|---------|
+| `raw_data.*_staging` | `replace` | Truncate + insert per run. Staging is ephemeral. |
+| `modelled.*` | `append` (technically) but **the SQL must do an UPSERT** | Use `INSERT ... ON CONFLICT (...) DO UPDATE`. |
+
+Reason: `modelled.*` writes must be **idempotent** — re-running the pipeline must produce the same final state, not duplicate rows.
+
+## UPSERT template
+
+```sql
+-- Block header (Mage)
+-- @data_exporter
+-- export_write_policy: append
+-- use_raw_sql: true
+
+INSERT INTO modelled.emissions (
+    actor_id,
+    gpc_reference_number,
+    reporting_year,
+    gas,
+    emissions_value,
+    datasource_name,
+    release_id,
+    created_at,
+    updated_at
+)
+SELECT
+    s.locode,
+    s.gpc_ref,
+    s.year,
+    s.gas,
+    s.value,
+    '{{ datasource_name }}'                       AS datasource_name,
+    '{{ release_id }}'::uuid                      AS release_id,
+    NOW(),
+    NOW()
+FROM raw_data.{{ staging_table }} s
+ON CONFLICT (actor_id, gpc_reference_number, reporting_year, gas, datasource_name)
+DO UPDATE SET
+    emissions_value = EXCLUDED.emissions_value,
+    release_id      = EXCLUDED.release_id,
+    updated_at      = NOW();
+```
+
+## Required columns on `modelled.*` writes
+
+- `created_at TIMESTAMPTZ` — `NOW()` on insert.
+- `updated_at TIMESTAMPTZ` — `NOW()` on every write.
+- `release_id UUID` — FK to `dataset_release`. Mandatory for production data; reference tables exempt (see `data-model-design.md` for the canonical list).
+
+If you find a `modelled.*` table missing these columns, that's tech debt — flag it in the PR. See `data-model-design.md` "backlog".
+
+## Identity (DO NOT GET WRONG)
+
+- City join key: `actor_id` / `locode`. **Never** `city_id`. See `identity-keys.mdc`.
+- `datasource_name` is exact-match — use `=`, not `LIKE`.
+
+## Anti-patterns
+
+- `TRUNCATE modelled.<table>` followed by reinsert — destroys provenance for other releases.
+- `DELETE FROM modelled.<table> WHERE datasource_name = '…'` then INSERT — same issue. Use UPSERT.
+- `JOIN city_polygon ON city_polygon.city_id = emissions.actor_id` — wrong key. See `identity-keys.mdc`.
+- Hardcoded UUIDs / dates in SQL — pull from `variables` in `metadata.yaml`.
+- Multiple statements without explicit transactions when they should be atomic.
+
+## Tests
+
+Every SQL exporter to `modelled.*` should be paired with a **post-condition** check:
+
+- Row count > 0 in the target slice (matches what came out of staging).
+- Identity-key uniqueness: `(actor_id, gpc_reference_number, reporting_year, gas, datasource_name)` is unique.
+- Plausibility: emissions values are non-negative; gas codes are in the allowed set.
+
+Implement these in a follow-up `dq_*` pipeline if not feasible inside the same one.

--- a/.cursor/rules/mage-pipelines.mdc
+++ b/.cursor/rules/mage-pipelines.mdc
@@ -1,0 +1,71 @@
+---
+description: Mage pipeline conventions — metadata.yaml, naming, variables, DAG shape.
+globs: cc-mage/pipelines/**/*.yaml,cc-mage/pipelines/**/*.yml
+alwaysApply: false
+---
+
+# Mage Pipeline Conventions
+
+## metadata.yaml is the contract
+
+Every pipeline folder must have a `metadata.yaml` with at minimum:
+
+```yaml
+name: ghgi_<sector>_<source>            # follow naming-conventions.md
+type: python                             # almost always
+description: <one sentence>             # MANDATORY — no `null`
+created_at: '<ISO timestamp>'
+
+variables:
+  bucket_name: test-global-api          # dev default; prod overrides via run config
+  release_version: '2026'
+  source_path: 's3://...'
+
+blocks:
+  - uuid: load_raw_<src>
+    type: data_loader
+    upstream_blocks: []
+    downstream_blocks: [cleaning_<src>]
+  # ... etc.
+```
+
+## Naming the pipeline
+
+Use the prefix table from `engineering-standards/naming-conventions.md`:
+
+| Prefix | Domain |
+|--------|--------|
+| `ghgi_` | GHG inventory |
+| `ccra_` | Climate risk assessment |
+| `dq_` | Data quality / validation |
+| `cap_` / `actions_` | City Action Plan |
+
+Pipelines tied to a release version add `_v<year>` (e.g. `ghgi_ippu_climatetrace_v2026`).
+
+## Block naming inside the pipeline
+
+```
+load_<src>            data_loader, S3 → DataFrame
+cleaning_<src>        transformer, type cleaning + column renames
+transformation_<src>  transformer, GPC sector mapping etc.
+<src>_staging         data_exporter, DataFrame → raw_data.<src>_<sector>_staging
+<src>_lookup          standalone SQL lookup (optional)
+locode_transformation SQL transform joining staging + lookup
+update_<src>_<table>  data_exporter, SQL → modelled.<table> (UPSERT)
+```
+
+## Variables
+
+Anything that varies across runs (year, bucket, source URL, release version) lives in `variables:`. Never hardcode in block code.
+
+## DAG shape
+
+The standard DAG is a **single linear chain** with multiple `update_*` exporters fanning out at the end. Avoid:
+
+- Cross-pipeline dependencies (each pipeline is its own unit).
+- Hidden side effects (a transformer that writes to S3 — only data_exporters write).
+- Loops / dynamic blocks unless absolutely necessary.
+
+## After changes
+
+If you change the DAG, update **both** the pipeline diagram in `ARCHITECTURE.md` (if it shows the pipeline) and the README of the related dataset review. Run the `docs-after-change` skill.

--- a/.cursor/rules/os-shell.mdc
+++ b/.cursor/rules/os-shell.mdc
@@ -1,0 +1,17 @@
+---
+description: Default to POSIX shell commands. Document Windows fallbacks only when needed.
+alwaysApply: true
+---
+
+# OS / Shell Defaults
+
+OEF runs macOS / Linux. Default every command to **POSIX `bash`/`zsh`**.
+
+- `ls`, `cat`, `grep`, `find`, `sed`, `awk` — preferred.
+- `&&` chain on success; `||` fallback; `;` sequence.
+- Forward-slash paths.
+- Heredocs for multi-line: `cat <<'EOF' > file …`.
+
+For agent-terminal invocations, assume non-interactive shell. No pagers (`--no-pager`, `| cat`).
+
+Windows users run inside WSL2 by default.

--- a/.cursor/rules/project-architecture.mdc
+++ b/.cursor/rules/project-architecture.mdc
@@ -1,0 +1,77 @@
+---
+description: CityCatalyst-global-data — repo layout, data stages, and conventions.
+alwaysApply: true
+---
+
+# CityCatalyst Global Data Architecture
+
+## What this repo is
+
+Production ETL feeding the **CityCatalyst Global API** with emissions and activity data from global / national publishers. Pipelines run in **Mage.ai** (`cc-mage/`); orchestrated locally via Docker on port 6789.
+
+## Top-level layout
+
+```
+CityCatalyst-global-data/
+├── cc-mage/                   # Mage project (DO NOT RENAME — baked into Mage config)
+│   ├── pipelines/<name>/      # one folder per pipeline; metadata.yaml is the contract
+│   ├── data_loaders/          # Python load blocks (S3 → memory)
+│   ├── transformers/          # Python or SQL transform blocks
+│   ├── data_exporters/        # Python or SQL export blocks (memory → DB or S3)
+│   ├── utils/                 # shared helpers
+│   ├── local_scripts/         # exploratory, NOT production
+│   └── io_config.yaml         # connection strings (gitignored values)
+├── dataset-review/
+│   ├── catalog/index.yaml     # registry of all datasets + releases
+│   ├── collections/           # thematic groupings of datasets
+│   └── reviews/<publisher>/   # per-publisher dataset reviews
+├── knowledge-base/            # topic-level domain notes (was `domain-knowledge/`)
+├── engineering-standards/     # team conventions — read these
+├── docs/                      # extra docs (incl. agent-runbook.md)
+├── AGENTS.md                  # agent brief (read first)
+├── ARCHITECTURE.md            # data architecture deep-dive
+└── docker-compose.yml         # local Mage on :6789
+```
+
+## Data stages (4)
+
+1. **`files`** (S3) — raw, untouched files from publishers.
+2. **`raw_data`** (S3 Parquet + `raw_data.<src>_<sector>_staging` Postgres tables) — typed and parsed.
+3. **`modelled`** (Postgres `modelled.*` schema, mirrored to S3) — standardised, primary input to Global API.
+4. **`reporting`** (Postgres + S3) — Metabase-tuned subset.
+
+## Pipeline contract (the standard flow)
+
+```
+data_loader (Python)         reads raw file from S3
+  └── data_exporter (Python) writes to raw_data staging (REPLACE)
+        └── transformer (SQL) staging → mapping/lookup
+              ├── data_exporter (SQL) → modelled.ghgi_methodology         (UPSERT)
+              ├── data_exporter (SQL) → modelled.activity_subcategory     (UPSERT)
+              ├── data_exporter (SQL) → modelled.emissions_factor          (UPSERT)
+              └── data_exporter (SQL) → modelled.emissions                 (UPSERT)
+```
+
+## Naming conventions (must match `engineering-standards/naming-conventions.md`)
+
+- **Pipeline prefixes**: `ghgi_`, `ccra_`, `dq_`, `cap_`, `actions_`. Suffix `_v<year>` for versioned releases.
+- **Staging tables**: `raw_data.<source>_<sector>_staging`.
+- **S3 paths** by stage / publisher / dataset — see `engineering-standards/naming-conventions.md`.
+
+## Key technical constraints (do not break)
+
+- **Do not rename `cc-mage/`** — Mage's project config is hardcoded.
+- **Do not delete release folders** under `dataset-review/reviews/<…>/releases/<v>/` — historical record.
+- **Staging tables are temporary** — never read from `raw_data.*_staging` from another pipeline.
+- **City identity = `actor_id` / `locode`**, never `city_id`. See `identity-keys.mdc`.
+- **`datasource_name` is an exact-string FK** to `publisher_datasource`.
+
+## Where the truth lives
+
+- Architecture & data flow: `ARCHITECTURE.md`.
+- Identity / FK rules: `AGENTS.md` and `.cursor/rules/identity-keys.mdc`.
+- DoD for new pipelines / releases: `engineering-standards/definition-of-done.md`.
+- Catalog conventions: `engineering-standards/documentation-and-metadata.md`.
+- Pipeline patterns: `engineering-standards/pipeline-design-patterns.md`.
+
+If those documents conflict, **`engineering-standards/` wins** and we open a PR to fix the lesser doc.

--- a/.cursor/rules/python-style.mdc
+++ b/.cursor/rules/python-style.mdc
@@ -1,0 +1,61 @@
+---
+description: Python style for Mage blocks and helper modules.
+globs: cc-mage/**/*.py,**/local_scripts/**/*.py
+alwaysApply: false
+---
+
+# Python Style — Mage
+
+## Imports
+
+- Standard library → third-party → first-party (`cc_mage.utils.…`).
+- Absolute imports inside `cc-mage/`.
+- One import per line for readability when multiple from same module.
+
+## Blocks must declare what they do
+
+Every Mage block file starts with a docstring:
+
+```python
+"""ghgi_ippu_climatetrace / cleaning_ippu_ct
+
+Cleans the raw ClimateTRACE IPPU CSV: filters to Brazil cities,
+renames columns to the canonical schema, groups by (locode, year, gas).
+
+Inputs:  pandas.DataFrame from `load_raw_ippu_ct`
+Outputs: pandas.DataFrame ready for `transformation_ippu_ct`
+"""
+```
+
+## Type hints
+
+Use them for **public** functions in shared modules. Mage block functions decorated with `@data_loader`/`@transformer`/`@data_exporter` — annotate the return type at minimum.
+
+## pandas
+
+- Avoid `inplace=True` (deprecated patterns; harder to read).
+- Chain operations with `.pipe()` for readability when 3+ steps.
+- Always `.copy()` when slicing in a way that the caller might mutate.
+
+## boto3 / S3
+
+- One client per block (don't recreate per row).
+- Use `paginator` for listings.
+- Stream large files — never `read()` a 1GB CSV into memory.
+
+## Logging
+
+- Use `logging` (not `print`) in code that runs in CI / scheduled jobs.
+- `logger = logging.getLogger(__name__)`.
+- Log row counts at INFO before / after each transform.
+
+## Testing
+
+- Mage `@test` decorators — see `data-quality-and-validation.md`. Layer 2 (structural) checks are mandatory; Layer 3 (plausibility) when ranges are knowable.
+- Pytest for shared helpers under `cc-mage/utils/`.
+
+## Anti-patterns
+
+- `assert output is not None` as the only test — useless. Test column presence, schema, row count > 0, identity-key uniqueness.
+- Hardcoded S3 keys / bucket names inside data-loader blocks — pull from `metadata.yaml` `variables`.
+- `pd.read_csv(url)` with no error handling — wrap in try/except + retries.

--- a/.cursor/rules/security-baseline.mdc
+++ b/.cursor/rules/security-baseline.mdc
@@ -1,0 +1,37 @@
+---
+description: Security baseline — secrets, AWS credentials, DB connection strings.
+alwaysApply: true
+---
+
+# Security Baseline — global-data
+
+## Secrets
+
+- **Never commit credentials.** Anything matching `*.env`, `credentials*.json`, `*key*.pem`, AWS keys (`AKIA…`), DB strings with passwords inline → hard stop.
+- `dev.env` is committed and **must not contain real secrets**. Use placeholders. Real values go in `.env` (gitignored) and `cc-mage/io_config.yaml` overrides.
+- AWS credentials go through the standard `~/.aws/credentials` profile — never inline in Mage blocks.
+
+## DB connections
+
+- Connection strings live in `io_config.yaml` (gitignored values) and are referenced by alias in Mage blocks (`config_profile`).
+- For destructive SQL (DROP, TRUNCATE, DELETE without WHERE), require a comment block explaining intent + a `metadata.yaml` `variable` to gate it.
+
+## SQL hygiene
+
+- Parameterise inputs (`%(var)s` for psycopg2-style or Mage variables). Never concatenate user input into SQL.
+- For `modelled.*` writes, prefer `INSERT … ON CONFLICT DO UPDATE` over `DELETE + INSERT`. See `mage-blocks-sql.mdc`.
+
+## S3
+
+- Buckets in dev: `test-global-api`. Buckets in prod: `global-api` (or as documented).
+- Listings via `boto3` should not enumerate the entire bucket — paginate and prefix-filter.
+- File names sanitise (drop spaces, lowercase) when uploading raw data — see `s3-upload-raw-data` skill.
+
+## Logging
+
+- Never log a full row containing PII (publisher contact info, citizen-level data). Aggregate counts only.
+- Mage block `print()` is OK for development; for production-relevant logs use `logging` (`logger = logging.getLogger(__name__)`).
+
+## Pipeline test data
+
+- `metadata.yaml` `variables.bucket_name` defaults to `test-global-api` (dev). Production overrides via the env-specific run config — never hardcode `global-api` in code.

--- a/.cursor/skills/add-dataset-release/SKILL.md
+++ b/.cursor/skills/add-dataset-release/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: add-dataset-release
+description: Add a new release of an existing dataset. Preserves old releases. Use when the user asks to bump a dataset version, add a new yearly release, or update production_approved status.
+---
+
+# add-dataset-release
+
+When a publisher ships an updated dataset (e.g. v2025 → v2026), add a **new** release folder alongside the old one.
+
+## Workflow
+
+### Step 1 — Add the new release folder
+
+```
+dataset-review/reviews/<publisher>/<dataset-id>/releases/<new-version>/
+├── review.yaml
+└── sample/      # optional tiny sample
+```
+
+**Do not delete** `releases/<old-version>/`. We preserve all releases.
+
+### Step 2 — Fill `review.yaml`
+
+Copy the previous release's `review.yaml` and update:
+
+- `dataset.coverage.value` if the geographic scope changed.
+- `key_attributes` if the schema changed (and document the diff in a `schema_changes:` block).
+- `integration.notes` for pipeline impact.
+- `production_ready: pending_validation` (start cautious).
+
+### Step 3 — Update `catalog/index.yaml`
+
+Inside the dataset entry's `releases:` list:
+
+1. Add the new release. Set `is_latest: true`.
+2. Flip the previous release's `is_latest: false`.
+3. **Do not change** `production_approved` on the old release.
+
+```yaml
+releases:
+  - version: '2026'
+    production_approved: false
+    is_latest: true
+    license: { spdx: '...', url: '...' }
+    pipeline_name: null
+    data_quality: null
+    urls: { source: '...', methodology: '...' }
+
+  - version: '2025'
+    production_approved: true
+    is_latest: false              # was true; flip to false
+    license: { spdx: '...', url: '...' }
+    pipeline_name: ghgi_<…>_v2025
+    data_quality: { layer_2_passed: true, layer_3_passed: true, notes: '…' }
+    urls: { source: '...', methodology: '...' }
+```
+
+### Step 4 — Pipeline plan
+
+If the new release requires pipeline changes:
+
+- Use the `scaffold-mage-pipeline` skill to clone the previous pipeline as `_v<new>` (e.g. `ghgi_ippu_climatetrace_v2026`).
+- Keep both pipelines runnable until the new one is `production_approved`.
+
+### Step 5 — Promotion (later, separate PR)
+
+When the new release passes Layers 2 + 3 in `engineering-standards/data-quality-and-validation.md`:
+
+1. Set `production_approved: true` on the new release.
+2. Fill `pipeline_name` and `data_quality`.
+3. Optionally retire the old release: `production_approved: false`. Do **not** delete files.
+
+### Step 6 — Document
+
+Run the `docs-after-change` skill (especially update the dataset README).
+
+## Anti-patterns
+
+- Deleting the old release folder.
+- Adding a new release without flipping the old `is_latest`.
+- Setting `production_approved: true` in the same PR as the file additions — split into two PRs (one for "add", one for "promote") so review focuses on the right thing.
+- Sharing a single pipeline across releases — fork the pipeline (`_v<year>`) so old data can still be regenerated.

--- a/.cursor/skills/add-publisher/SKILL.md
+++ b/.cursor/skills/add-publisher/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: add-publisher
+description: Add a new data publisher and its first dataset review. Creates folder skeleton, README, and catalog entry. Use when the user asks to onboard a publisher, add a new data source, or register a new dataset publisher.
+---
+
+# add-publisher
+
+Onboard a new publisher (e.g. EU Eurostat, ClimateTRACE, EDGAR) into `dataset-review/`.
+
+## Workflow
+
+### Step 1 — Pick slugs
+
+- `<publisher>` slug: short, lowercase, kebab-case (`eurostat`, `climatetrace`, `edgar`, `world-bank`).
+- `<dataset-id>` slug: `<publisher>-<dataset-name>` (`eurostat-energy`, `climatetrace-onroad`).
+
+### Step 2 — Folder skeleton
+
+```
+dataset-review/reviews/<publisher>/<dataset-id>/
+├── README.md
+└── releases/<version>/
+    ├── review.yaml
+    └── sample/                  # (optional) tiny sample data, NOT prod data
+```
+
+### Step 3 — `README.md` (per dataset)
+
+```md
+# <Dataset Human Name>
+
+Source: <Publisher Human Name> · License: <SPDX or "see source">
+
+## What it is
+1–3 sentences describing the dataset (coverage, themes, granularity).
+
+## Why we want it
+Bullet list — discovery, finance signal, geographic coverage, methodological reference, etc.
+
+## Releases
+
+- `releases/<version>/` — see [`review.yaml`](releases/<version>/review.yaml). Status: <pending_validation|production_ready>.
+
+## Open questions
+Bullet list of things to check during integration (e.g. units, deduplication, license clauses).
+```
+
+### Step 4 — `releases/<version>/review.yaml`
+
+```yaml
+publisher:
+  name: <Publisher Human Name>
+  short_name: <publisher>
+  url: '<homepage>'
+
+dataset:
+  id: <dataset-id>
+  name: <Dataset Human Name>
+  description: <one sentence>
+  source_format: csv|json|geojson|parquet|api
+  api_endpoint: '<url if api>'
+  coverage:
+    type: country|global|city
+    value: '<countries / "global" / specific city>'
+
+themes:
+  - climate
+  - <…>
+
+key_attributes:
+  - name: <field>
+    type: string|int|float|datetime
+    description: <…>
+
+integration:
+  recommended_pattern: file_based | api_based
+  notes: |
+    <how to ingest into raw_data and modelled>
+
+license:
+  spdx: '<SPDX id or "custom">'
+  url: '<license URL>'
+  redistribution_allowed: yes|no|conditional
+
+production_ready: pending_validation
+```
+
+### Step 5 — Catalog entry
+
+Append to `dataset-review/catalog/index.yaml`:
+
+```yaml
+- id: <dataset-id>
+  name: <Dataset Human Name>
+  publisher: <publisher>
+  coverage: { type: country|global|city, value: '<…>' }
+  themes: [...]
+  update_frequency: annual|quarterly|monthly|adhoc
+  priority: high|medium|low
+  releases:
+    - version: '<version>'
+      production_approved: false      # always start false
+      is_latest: true
+      license: { spdx: '<…>', url: '<…>' }
+      pipeline_name: null              # filled when production_approved=true
+      data_quality: null
+      urls: { source: '<…>', methodology: '<…>' }
+```
+
+### Step 6 — Document
+
+- Run the `docs-after-change` skill.
+- If the dataset belongs in a thematic collection, add the id under `dataset-review/collections/collection.yaml`.
+
+## Checklist
+
+- [ ] Folder created under `reviews/<publisher>/<dataset-id>/`.
+- [ ] README explains what + why + open questions.
+- [ ] `releases/<version>/review.yaml` filled (no nulls in required fields).
+- [ ] `catalog/index.yaml` appended (`production_approved: false`).
+- [ ] `collections/collection.yaml` updated if applicable.
+- [ ] No production data committed under `sample/` — tiny excerpts only.

--- a/.cursor/skills/commit-message-standards/SKILL.md
+++ b/.cursor/skills/commit-message-standards/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: commit-message-standards
+description: Generate Conventional Commits messages for global-data. Pairs with pull-request-standards.
+---
+
+# commit-message-standards — global-data
+
+Conventional Commits, ≤72 chars per line, imperative summary.
+
+```
+<type>(<scope>): <imperative summary>
+
+<body — explain WHY, wrap at 72>
+
+<footer — Refs: ON-####>
+```
+
+Recommended `<scope>`:
+- `pipeline` — Mage pipeline (added / changed / removed).
+- `mage` — Mage project / docker / config.
+- `catalog` — `dataset-review/catalog/*`.
+- `review` — `dataset-review/reviews/*`.
+- `kb` — `knowledge-base/*`.
+- `standards` — `engineering-standards/*`.
+- `ci`, `docker`, `chore`, `docs`.
+
+Examples:
+
+```
+feat(pipeline): add ghgi_ippu_climatetrace v2026 release
+
+Pipeline mirrors v2025 with the new bucket layout. Updates
+catalog entry to set v2026 as production_approved with a
+data_quality summary.
+
+Refs: ON-5712
+```
+
+```
+fix(catalog): drop duplicate eurostat dataset id
+
+The 2025 release was registered twice with slightly different
+slugs, causing collections/collection.yaml to point at the wrong
+release. Keep `eu-eurostat-energy-2025`, remove the typo entry.
+```
+
+```
+docs(standards): clarify Layer 2 schema check expectations
+```
+
+Anti-patterns: `wip`, `update`, `fixed bug`, `cleanup`. Always state the WHY in the body when it isn't obvious from the diff.

--- a/.cursor/skills/definition-of-done-check/SKILL.md
+++ b/.cursor/skills/definition-of-done-check/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: definition-of-done-check
+description: Run the engineering-standards Definition of Done checklist against a pipeline or release. Use before promoting production_approved=true, or when the user asks "is this ready for prod?".
+---
+
+# definition-of-done-check
+
+Authoritative checklist lives in `engineering-standards/definition-of-done.md`. This skill is the agent's runner.
+
+## When to use
+
+- Before flipping `production_approved: true` on a dataset release.
+- Before merging a "promote pipeline" PR.
+- When asked "is `<pipeline>` ready for prod?".
+
+## Run order
+
+### A. New pipeline
+
+- [ ] Pipeline name follows `naming-conventions.md`.
+- [ ] `metadata.yaml.description` is non-null and matches the README.
+- [ ] All variables in `metadata.yaml.variables` (no hardcoded values).
+- [ ] Layer 2 tests present on every transformer and exporter (schema, row counts, identity uniqueness).
+- [ ] Layer 3 tests present where ranges are knowable (plausibility flags).
+- [ ] Catalog entry exists in `catalog/index.yaml`, `production_approved: true`, `pipeline_name` and `data_quality` non-null.
+- [ ] `dataset-review/reviews/<publisher>/<dataset>/README.md` mentions the pipeline.
+- [ ] Notion methodology page linked from `urls` in catalog.
+- [ ] Peer review in PR (CTO sign-off).
+
+### B. New release of existing pipeline
+
+- [ ] New release folder added under `reviews/<publisher>/<dataset>/releases/<version>/`.
+- [ ] Old release `is_latest: false` flipped.
+- [ ] If the schema changed, `review.yaml` includes a `schema_changes:` block.
+- [ ] Pipeline forked as `_v<year>` (old still runnable).
+- [ ] Layer 2 + 3 tests pass on a real run against the new release.
+- [ ] PR includes row counts from a successful local run.
+
+## Output
+
+Run silently if everything passes. Otherwise output:
+
+```markdown
+- [ ] <check that failed>
+  - reason: <evidence from file>
+  - fix: <minimal action>
+```
+
+If 5+ checks fail, also recommend splitting into a smaller PR.

--- a/.cursor/skills/definition-of-done-check/SKILL.md
+++ b/.cursor/skills/definition-of-done-check/SKILL.md
@@ -25,7 +25,7 @@ Authoritative checklist lives in `engineering-standards/definition-of-done.md`. 
 - [ ] Catalog entry exists in `catalog/index.yaml`, `production_approved: true`, `pipeline_name` and `data_quality` non-null.
 - [ ] `dataset-review/reviews/<publisher>/<dataset>/README.md` mentions the pipeline.
 - [ ] Notion methodology page linked from `urls` in catalog.
-- [ ] Peer review in PR (CTO sign-off).
+- [ ] Peer review in PR (core-team sign-off).
 
 ### B. New release of existing pipeline
 

--- a/.cursor/skills/docs-after-change/SKILL.md
+++ b/.cursor/skills/docs-after-change/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: docs-after-change
+description: Mandatory after any code/config change. Keeps READMEs, ARCHITECTURE, and dataset reviews in sync.
+---
+
+# docs-after-change — global-data
+
+Run this **after every change** and **before** handing back to the user.
+
+## Touched a pipeline?
+
+- Update `dataset-review/reviews/<publisher>/<dataset>/README.md` if the pipeline shape or scope changed.
+- Update the per-release `review.yaml` if you added a new release or changed `production_ready`.
+- Update `catalog/index.yaml` for the affected dataset (release `is_latest`, `production_approved`, `pipeline_name`, `data_quality`).
+- If the DAG diagram in `ARCHITECTURE.md` shows this pipeline, update it.
+
+## Touched the data model?
+
+- Update `engineering-standards/data-model-design.md` "backlog" if the change closed a gap.
+- Update `ARCHITECTURE.md` table-summary if a `modelled.*` table changed.
+
+## Touched standards?
+
+- Cross-link any new standards file from `AGENTS.md` and `README.md`.
+
+## Touched the README itself?
+
+- Make sure references match the current tree (e.g. `knowledge-base/`, not the old `domain-knowledge/`).
+- Verify command examples still work (`docker compose up`, `mage start cc-mage`).
+
+## Reporting
+
+Final reply to the user must include:
+
+- which docs you reviewed
+- which docs you changed and why (1–3 bullets)
+- any docs you intentionally did **not** change (and why)

--- a/.cursor/skills/pr-review-gate/SKILL.md
+++ b/.cursor/skills/pr-review-gate/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: pr-review-gate
+description: Review a global-data PR for high-impact issues only (≥7/10). Pipeline correctness, identity-key safety, idempotency, catalog hygiene.
+---
+
+# pr-review-gate — global-data
+
+Same philosophy as the cross-repo skill: report only `impact >= 7` findings.
+
+## Must-check list (in addition to the cross-repo defaults)
+
+- **Identity keys** — `actor_id` / `locode` used as city key; `datasource_name` exact-match. Anything else is a bug.
+- **Idempotency** — `modelled.*` SQL writes are UPSERTs (or there's an explicit reason).
+- **Catalog drift** — if `production_approved: true` was set, `pipeline_name` and `data_quality` are filled.
+- **Schema drift** — if a `modelled.*` table is altered, all writers are updated in the same PR (or an explicit follow-up issue is referenced).
+- **Naming** — pipeline / staging / S3 paths follow `engineering-standards/naming-conventions.md`.
+- **Tests** — Mage `@test` checks beyond `assert output is not None` (schema, row count, identity uniqueness, plausibility).
+
+## Output format
+
+Same as cross-repo:
+
+```markdown
+- file: dataset-review/catalog/index.yaml
+  line: 142
+  severity: 9/10
+  comment: production_approved=true but data_quality is null. Either fill it or set production_approved=false.
+```
+
+If nothing ≥ 7/10 → output exactly:
+
+```markdown
+No review comments above 7/10 impact.
+```
+
+Max 5 findings. Concrete, evidence-based.

--- a/.cursor/skills/prompt-schema-authoring/SKILL.md
+++ b/.cursor/skills/prompt-schema-authoring/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: prompt-schema-authoring
+description: Author or update LLM prompts in this repo using the standard <role>/<task>/<input>/<output> structure.
+---
+
+# prompt-schema-authoring — global-data
+
+Same as the cross-repo skill (see CityCatalyst). Used here for any LLM-driven helper inside `cc-mage/prompts/` or experimental notebooks.
+
+## Required structure
+
+```md
+<role>...</role>
+<task>...</task>
+<input>JSON object with: - field (type): purpose</input>
+<tools>...</tools>          <!-- only if tools exist -->
+<output>...</output>
+<example_output>...</example_output>
+```
+
+Keep prompts under 300 lines. Split by responsibility if longer. Pair every prompt change with the matching Pydantic / dataclass model in code.

--- a/.cursor/skills/pull-request-standards/SKILL.md
+++ b/.cursor/skills/pull-request-standards/SKILL.md
@@ -44,5 +44,5 @@ Assume the branch is already pushed when the user asks to create a PR. Do **not*
 ## Who merges
 
 - **Pipelines / catalog / code** — any tech-team member after standard review (≥1 approval, CI green).
-- **Agentic + standards foundation** (`AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, `docs/agent-runbook.md`) — CTO sign-off required; then anyone merges.
+- **Agentic + standards foundation** (`AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, `docs/agent-runbook.md`) — core-team sign-off required; then anyone merges.
 - **Agents** never merge their own PRs and do not open PRs unless explicitly told to in the active task. If asked to open the PR, use `gh pr create --base develop`.

--- a/.cursor/skills/pull-request-standards/SKILL.md
+++ b/.cursor/skills/pull-request-standards/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pull-request-standards
+description: Create pull requests with repository-derived context, concise title/body standards. Use when creating, automating, or polishing a PR for global-data.
+---
+
+# Pull Request Standards — global-data
+
+Use this whenever you draft, automate, or polish a PR for `CityCatalyst-global-data`.
+
+## Derive context
+
+- Owner / repo: `git remote get-url origin` → `Open-Earth-Foundation/CityCatalyst-global-data`.
+- Head: `git rev-parse --abbrev-ref HEAD`.
+- Base: **`develop`** (this repo's default).
+
+## Title
+
+- ≤72 chars, imperative.
+- Conventional-Commit-flavoured: `feat(pipeline): add ghgi_eurostat_v2026`.
+- Ticket prefix when applicable.
+
+## Body (short, practical)
+
+```markdown
+## Summary
+1–3 sentences: what changed and why.
+
+## Changes
+- bullet
+- bullet
+
+## Catalog updates (if applicable)
+- which `catalog/index.yaml` entry was changed
+- which `dataset-review/.../review.yaml` was added or updated
+
+## Pipeline runs (if applicable)
+- pipeline name + dev run timestamp + row counts
+```
+
+## Push policy
+
+Assume the branch is already pushed when the user asks to create a PR. Do **not** run `git push` unless explicitly asked.
+
+## Who merges
+
+- **Pipelines / catalog / code** — any tech-team member after standard review (≥1 approval, CI green).
+- **Agentic + standards foundation** (`AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, `docs/agent-runbook.md`) — CTO sign-off required; then anyone merges.
+- **Agents** never merge their own PRs and do not open PRs unless explicitly told to in the active task. If asked to open the PR, use `gh pr create --base develop`.

--- a/.cursor/skills/repo-doc-audit/SKILL.md
+++ b/.cursor/skills/repo-doc-audit/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: repo-doc-audit
+description: One-off full repo documentation audit. Use only when explicitly requested. Disabled by default to avoid expensive runs.
+disable-model-invocation: true
+---
+
+# repo-doc-audit — global-data
+
+Run on demand for a full repo audit. Expected output: a short report + suggested fixes.
+
+## Scope
+
+- `README.md` accuracy (commands, paths, env vars, references — current tree uses `knowledge-base/` not `domain-knowledge/`).
+- `AGENTS.md` and `ARCHITECTURE.md` against the actual tree.
+- All `engineering-standards/*.md` for internal consistency (terminology, paths, identity keys).
+- Per-publisher `dataset-review/reviews/<…>/README.md` against the latest `review.yaml`.
+- `catalog/index.yaml` completeness — every `production_approved: true` row has `pipeline_name` + `data_quality`.
+- Pipeline `metadata.yaml` `description` is non-null and matches the README.
+- `requirements.txt` covers what the blocks actually import (boto3, sqlalchemy, requests, etc.).
+
+## Method
+
+1. Read the current tree (`find . -type f`) and compare against doc claims.
+2. For each mismatch, score impact 1–10. Report ≥ 5 only.
+3. Provide minimal-edit suggestions.
+4. Apply edits only if the user explicitly says so.
+
+## Non-goals
+
+- Style enforcement.
+- Rewriting unfamiliar standards prose.

--- a/.cursor/skills/scaffold-mage-pipeline/SKILL.md
+++ b/.cursor/skills/scaffold-mage-pipeline/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: scaffold-mage-pipeline
+description: Scaffold a new Mage pipeline (folder + metadata + standard block stubs). Use when the user asks to create, add, or scaffold a new pipeline, or to fork a versioned pipeline (_v<year>).
+---
+
+# scaffold-mage-pipeline
+
+Generate the standard Mage pipeline folder + metadata + block stubs.
+
+## Workflow
+
+### Step 1 — Pick a name
+
+Follow `engineering-standards/naming-conventions.md`:
+
+```
+<prefix>_<sector>_<source>[_v<year>]
+```
+
+Examples:
+- `ghgi_ippu_climatetrace_v2026`
+- `ccra_floods_climateraltm_v2025`
+- `dq_ghgi_uniqueness`
+
+### Step 2 — Folder structure
+
+```
+cc-mage/pipelines/<name>/
+└── metadata.yaml
+
+cc-mage/data_loaders/load_<source>.py
+cc-mage/transformers/cleaning_<source>.py
+cc-mage/transformers/transformation_<source>.py
+cc-mage/data_exporters/<source>_staging.py
+cc-mage/transformers/<source>_lookup.sql       # optional
+cc-mage/transformers/locode_transformation.sql
+cc-mage/data_exporters/update_<source>_emissions.sql
+cc-mage/data_exporters/update_<source>_sector_activity.sql
+cc-mage/data_exporters/update_<source>_emission_factor.sql
+```
+
+(Reuse existing block files when possible — Mage blocks are global to the project.)
+
+### Step 3 — `metadata.yaml`
+
+```yaml
+name: <name>
+type: python
+description: |
+  Ingest <source> <sector> data into modelled.* tables.
+  Source: <publisher URL>. Release: <version>.
+created_at: '<ISO timestamp>'
+
+variables:
+  bucket_name: test-global-api
+  release_version: '<version>'
+  source_path: 's3://<bucket>/<key>'
+  datasource_name: '<exact match in publisher_datasource>'
+
+blocks:
+  - uuid: load_<source>
+    type: data_loader
+    upstream_blocks: []
+    downstream_blocks: [cleaning_<source>]
+
+  - uuid: cleaning_<source>
+    type: transformer
+    upstream_blocks: [load_<source>]
+    downstream_blocks: [transformation_<source>]
+
+  - uuid: transformation_<source>
+    type: transformer
+    upstream_blocks: [cleaning_<source>]
+    downstream_blocks: [<source>_staging]
+
+  - uuid: <source>_staging
+    type: data_exporter
+    upstream_blocks: [transformation_<source>]
+    downstream_blocks: [locode_transformation]
+
+  - uuid: locode_transformation
+    type: transformer
+    language: sql
+    upstream_blocks: [<source>_staging]
+    downstream_blocks:
+      - update_<source>_emissions
+      - update_<source>_sector_activity
+      - update_<source>_emission_factor
+
+  - uuid: update_<source>_emissions
+    type: data_exporter
+    language: sql
+    configuration:
+      use_raw_sql: true
+      export_write_policy: append
+    upstream_blocks: [locode_transformation]
+
+  - uuid: update_<source>_sector_activity
+    type: data_exporter
+    language: sql
+    configuration:
+      use_raw_sql: true
+      export_write_policy: append
+    upstream_blocks: [locode_transformation]
+
+  - uuid: update_<source>_emission_factor
+    type: data_exporter
+    language: sql
+    configuration:
+      use_raw_sql: true
+      export_write_policy: append
+    upstream_blocks: [locode_transformation]
+```
+
+### Step 4 — Block stubs
+
+For each block, follow `mage-blocks-python.mdc` / `mage-blocks-sql.mdc`. Mandatory:
+
+- Top-of-file docstring (block name + brief).
+- Real `@test` decorators (schema + uniqueness + plausibility — not just `assert output is not None`).
+- For SQL: `INSERT … ON CONFLICT … DO UPDATE` (idempotent UPSERT into `modelled.*`).
+
+### Step 5 — Catalog + review
+
+Use `add-publisher` (if new publisher) or `add-dataset-release` (if new release). Set `production_approved: false` initially.
+
+### Step 6 — Local smoke run
+
+```bash
+docker compose up -d
+# UI at http://localhost:6789 — run the pipeline against a small subset
+```
+
+Capture the row counts from the staging table and the modelled write — paste into the PR description.
+
+### Step 7 — Document
+
+Run `docs-after-change`. Update `dataset-review/reviews/<publisher>/<dataset>/README.md` to mention the new pipeline.
+
+## Checklist
+
+- [ ] Naming follows `naming-conventions.md`.
+- [ ] `metadata.yaml.description` is non-null.
+- [ ] All variables declared (no hardcoded bucket / path / version).
+- [ ] Block files exist; tests are real (Layer 2+).
+- [ ] SQL exporters use `INSERT … ON CONFLICT … DO UPDATE`.
+- [ ] Catalog and review updated.
+- [ ] Local smoke run captured (row counts in PR body).

--- a/.cursor/skills/script-quality-gate/SKILL.md
+++ b/.cursor/skills/script-quality-gate/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: script-quality-gate
+description: Apply when adding or modifying runnable scripts (cc-mage/local_scripts/*, helpers, CLI tools).
+---
+
+# script-quality-gate — global-data
+
+Use when creating or changing a runnable script (anything with `if __name__ == "__main__"`).
+
+## Required
+
+- Top-level docstring (Brief / Inputs / Outputs / Usage).
+- `argparse` for CLIs, `--help` reachable.
+- Work inside `def main()`. No side effects at import time.
+- `pathlib.Path` for paths.
+- `logging` for production-meaningful output.
+- Absolute imports.
+
+## Location
+
+- One-off / exploratory: `cc-mage/local_scripts/<name>.py` (NOT shipped in production image).
+- Shared helpers: `cc-mage/utils/<module>.py`.
+- Standalone tools: top-level `scripts/<name>.py` (only if no Mage block fits).
+
+## After the checklist
+
+Run the `docs-after-change` skill.

--- a/.cursor/skills/simplify-after-change/SKILL.md
+++ b/.cursor/skills/simplify-after-change/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: simplify-after-change
+description: Simplify only the files touched in this change. Preserve behaviour. No new dependencies.
+---
+
+# simplify-after-change — global-data
+
+Same philosophy as the cross-repo skill. Apply only to:
+
+1. files edited in this change, or
+2. the currently open file(s).
+
+Do not refactor unrelated modules.
+
+## Specifically for Mage blocks
+
+- Remove leftover Jupyter-style `display(df)` / `df.head()` calls.
+- Inline single-use helpers if they live next to the only caller and don't aid readability.
+- Replace `inplace=True` chains with explicit assignment.
+- Drop unused `kwargs` reads.
+- Drop `@test` blocks that only assert `output is not None` — replace with a real schema/uniqueness check (or delete and file a follow-up issue).
+
+## Non-negotiables
+
+- Preserve identity-key handling (`locode` / `actor_id`, `datasource_name`).
+- Preserve idempotency of `modelled.*` writes.
+- Preserve logging at INFO+ levels.
+- Do not introduce new deps in `cc-mage/requirements.txt`.
+
+## Output
+
+Bullet-list what you simplified and why.

--- a/.cursor/skills/sql-block-idempotency/SKILL.md
+++ b/.cursor/skills/sql-block-idempotency/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: sql-block-idempotency
+description: Audit a SQL data_exporter block for idempotency (UPSERT semantics, no destructive truncates). Use when reviewing or writing a SQL block targeting modelled.*.
+---
+
+# sql-block-idempotency
+
+`modelled.*` writes must be idempotent — re-running the pipeline must produce the same final state.
+
+## Required pattern
+
+```sql
+INSERT INTO modelled.<table> (<cols>, created_at, updated_at)
+SELECT <…>, NOW(), NOW()
+FROM <staging>
+ON CONFLICT (<unique_key_cols>)
+DO UPDATE SET
+    <non_key_col_a> = EXCLUDED.<non_key_col_a>,
+    <non_key_col_b> = EXCLUDED.<non_key_col_b>,
+    updated_at      = NOW();
+```
+
+## Audit checklist
+
+- [ ] `INSERT INTO modelled.<table>` — no `DELETE` / `TRUNCATE` of `modelled.*`.
+- [ ] `ON CONFLICT (<unique key>) DO UPDATE` present.
+- [ ] Conflict columns match a real unique constraint (`SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'modelled.<table>'::regclass`).
+- [ ] `created_at` only set on insert (`NOW()` initially, kept on update via `EXCLUDED.created_at` only if you want it preserved — usually leave the existing value alone, so don't list `created_at` in DO UPDATE SET).
+- [ ] `updated_at = NOW()` in DO UPDATE SET.
+- [ ] `release_id` set on every write (mandatory for `modelled.*` per `data-model-design.md`).
+- [ ] `datasource_name` is the exact-match value, not a `LIKE` pattern.
+
+## Anti-patterns
+
+- `DELETE FROM modelled.<table> WHERE datasource_name = '…'; INSERT …` — destroys provenance and breaks foreign keys.
+- `TRUNCATE modelled.<table>` — never. This isn't staging.
+- `INSERT … ON CONFLICT DO NOTHING` for fact tables — silently drops updated values.
+- Missing `release_id` — orphans the row from its dataset release.
+
+## Fix recipe
+
+If you find a destructive pattern:
+
+1. Identify the table's unique key (`pg_constraint`).
+2. Rewrite as `INSERT … ON CONFLICT … DO UPDATE`.
+3. Add a smoke `@test` block that runs the same input twice and asserts the row count is unchanged.
+4. Note the change in the PR body — this is a behavioural change worth flagging.

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,34 @@
+# Files / dirs Cursor should NOT index for embeddings or context.
+# Keep this short — narrower index = faster, more focused agents.
+
+# Build artifacts / Python
+**/__pycache__/
+**/.pytest_cache/
+**/.venv/
+**/venv/
+**/dist/
+**/build/
+
+# Mage local state — large, machine-specific
+mage_data/
+**/mage_data/
+
+# Docker / OS noise
+.DS_Store
+**/.DS_Store
+
+# Local secrets and env
+.env
+.env.local
+**/credentials*.json
+**/*.pem
+
+# Heavy data / fixtures
+**/*.gpkg
+**/*.parquet
+**/*.csv
+**/*.geojson
+
+# Logs
+**/logs/
+**/*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,57 +1,145 @@
-# Agent Context — CityCatalyst Global Data
+# CityCatalyst Global Data — Agent Brief
 
-This file gives an AI agent the working knowledge needed to reason about this repo correctly.
-Read this alongside `ARCHITECTURE.md` for system design, `dataset-review/catalog/index.yaml`
-for the current dataset registry, and `engineering-standards/` for team conventions and the
-definition of done.
+**Read this first.** Every AI agent (Cursor, Cursor Cloud Agent, agentic-coder, Codex, Claude Code) and every new human contributor opens this file before touching the repo.
+
+This is a 1-page contract. Full conventions live in `.cursor/rules/`, named workflows in `.cursor/skills/`, and team standards in `engineering-standards/`.
 
 ---
 
+## What this repo is
+
+Production ETL feeding the **CityCatalyst Global API**. Pipelines run in **Mage.ai** (`cc-mage/`), orchestrated locally via Docker on port 6789. Data flows in 4 stages: `files` → `raw_data` → `modelled` → `reporting`. See `ARCHITECTURE.md` for the deep-dive.
 
 ## Identity mappings you must get right
 
-These are the most common source of mistakes in SQL and Python:
+These are the most common source of mistakes in SQL and Python. **Internalise them.**
 
 | Identifier | What it is | Where it appears |
-|------------|-----------|-----------------|
+|------------|------------|-----------------|
 | `actor_id` | UN/LOCODE city code (e.g. `BR SAO`) | `modelled.emissions`, `modelled.emissions_factor` |
 | `locode` | Same as `actor_id` — the city's primary key | `modelled.city_polygon` |
-| `city_id` | GeoHash of the city centroid — NOT the primary key | `modelled.city_polygon`, some staging tables |
-| `datasource_name` | Short string key linking emissions back to a publisher | All `modelled` tables — must match `publisher_datasource.datasource_name` exactly |
+| `city_id` | GeoHash of the city centroid — **NOT** a primary key. **Never** join on this | `modelled.city_polygon`, some staging tables |
+| `datasource_name` | Short string key linking emissions back to a publisher. **Exact-match FK** | All `modelled.*` tables — must match `publisher_datasource.datasource_name` exactly |
 | `gpc_reference_number` | GPC sector ref (e.g. `II.1.1`) | `modelled.emissions`, `modelled.ghgi_methodology` |
-| `gpcmethod_id` | UUID linking an emission record to a methodology | FK between `emissions`, `activity_subcategory`, `ghgi_methodology` |
+| `gpcmethod_id` | UUID linking emission record to a methodology | FK between `emissions`, `activity_subcategory`, `ghgi_methodology` |
 
-Always use `actor_id` / `locode` for city identity — never `city_id`. When referencing
-datasets, `datasource_name` must be an exact string match.
+Always use `actor_id` / `locode` for city identity — never `city_id`. When referencing datasets, `datasource_name` must be an exact string match (use `=`, not `LIKE`).
 
----
+The full machine-readable rule lives at `.cursor/rules/identity-keys.mdc`.
 
 ## Critical constraints
 
-**Do not rename `cc-mage/`** — the folder name is baked into Mage.ai's project configuration.
-Renaming it breaks the Docker setup entirely.
-
-**Do not delete release folders in `dataset-review/reviews/`** — old releases must be preserved.
-When a dataset is updated, create a new release folder alongside the old one. The catalog
-`production_approved_release` field is what determines which release is currently active.
-
-**Staging tables are temporary by design** — `raw_data.*_staging` tables are intermediate.
-Do not treat them as a data source for other pipelines or reporting.
-
-**Do not use `city_id` as the city join key** — use `actor_id` / `locode`.
-
----
+- **Do not rename `cc-mage/`** — Mage's project config is hardcoded.
+- **Do not delete release folders** under `dataset-review/reviews/<…>/releases/<v>/`. Old releases are part of the historical record. When updating, add a new `<v+1>` and flip `is_latest`.
+- **Staging tables are temporary** — `raw_data.*_staging` is intermediate. Don't read from another pipeline.
+- **Don't use `city_id` as a join key** — use `actor_id` / `locode`.
 
 ## Things that look similar but are different
 
 **`emissions_factor` vs `formula_input`:**
-- `emissions_factor` — standard EF used in `emissions = activity × EF` calculations.
-- `formula_input` — parameters for more complex calculations where the simple formula doesn't
-  apply (e.g. waste composition factors, biological treatment parameters).
+- `emissions_factor` — standard EF used in `emissions = activity × EF`.
+- `formula_input` — parameters for more complex calculations (waste composition, biological treatment …).
 
 **Some publishers have two pipeline patterns:**
-- File-based — reads from S3, standard `extract → stage → modelled` flow. Authoritative for production.
-- API-based — pulls directly from the publisher API for a specific city. Ad-hoc only, not production ingestion.
+- **File-based** — reads from S3, standard `extract → stage → modelled` flow. Authoritative for production.
+- **API-based** — pulls directly from publisher API for a specific city. Ad-hoc only, not production ingestion.
 
-When in doubt about which pattern a pipeline uses, read its block code — `metadata.yaml`
-descriptions may be outdated.
+When in doubt about which pattern a pipeline uses, **read the block code** — `metadata.yaml.description` may be outdated.
+
+---
+
+## What you must NOT do
+
+- **Do not open a PR unless explicitly told to** in the active task. Push the branch and stop; a human reviews and opens it.
+- **Do not merge your own PR if you are an agent.** Humans review and merge.
+- **Do not commit secrets.** AWS keys, DB passwords, `*.env`, `credentials*.json` → hard stop.
+- **Do not flip `production_approved: true`** without running the `definition-of-done-check` skill first.
+- **Do not introduce new deps** in `cc-mage/requirements.txt` without justification.
+- **Do not modify `AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, or `docs/agent-runbook.md` without CTO review.** These are the agentic + standards foundation; the CTO is the curator. (Product / pipeline code merges are unaffected — any tech-team member can merge as today.)
+
+## What you must always do
+
+- Branch off `develop`. Conventional Commits with ticket where applicable.
+- Run `docs-after-change` after any edit.
+- Use the matching skill: `add-publisher` / `add-dataset-release` / `scaffold-mage-pipeline` / `sql-block-idempotency` / `definition-of-done-check`.
+- Make `modelled.*` writes idempotent (`INSERT … ON CONFLICT … DO UPDATE`).
+
+---
+
+## Where to find what
+
+### Rules
+
+| Topic | Open |
+|-------|------|
+| General code taste | `.cursor/rules/general.mdc` |
+| Repo + data architecture | `.cursor/rules/project-architecture.mdc` |
+| Identity keys (locode, actor_id, datasource_name) | `.cursor/rules/identity-keys.mdc` |
+| Branches, commits, PRs | `.cursor/rules/git-conventions.mdc` |
+| Security baseline (secrets, AWS, DB) | `.cursor/rules/security-baseline.mdc` |
+| OS / shell defaults | `.cursor/rules/os-shell.mdc` |
+| Python style for blocks | `.cursor/rules/python-style.mdc` |
+| Mage pipelines | `.cursor/rules/mage-pipelines.mdc` |
+| Mage Python blocks | `.cursor/rules/mage-blocks-python.mdc` |
+| Mage SQL blocks (UPSERT) | `.cursor/rules/mage-blocks-sql.mdc` |
+| Dataset review + catalog | `.cursor/rules/dataset-review-catalog.mdc` |
+
+### Skills
+
+| Want to | Use |
+|---------|-----|
+| Scaffold a new Mage pipeline | `scaffold-mage-pipeline` |
+| Add a new publisher / dataset | `add-publisher` |
+| Add a new release of a dataset | `add-dataset-release` |
+| Audit a SQL block for idempotency | `sql-block-idempotency` |
+| Run the production-readiness checklist | `definition-of-done-check` |
+| Generate S3 upload commands | `s3-upload-raw-data` |
+| Write a commit message | `commit-message-standards` |
+| Open / draft a PR | `pull-request-standards` |
+| Review a PR | `pr-review-gate` |
+| Update docs after a change | `docs-after-change` |
+| Simplify code touched in this PR | `simplify-after-change` |
+| Author / update an LLM prompt | `prompt-schema-authoring` |
+| Quality-gate a runnable script | `script-quality-gate` |
+| Run a full repo doc audit | `repo-doc-audit` (manual trigger only) |
+
+### Standards (authoritative)
+
+These are the team's canonical engineering standards. Rules and skills above are derived from them — when they disagree, **`engineering-standards/` wins** and we open a PR to fix the lesser doc.
+
+- `engineering-standards/data-quality-and-validation.md`
+- `engineering-standards/pipeline-design-patterns.md`
+- `engineering-standards/documentation-and-metadata.md`
+- `engineering-standards/naming-conventions.md`
+- `engineering-standards/project-structure-and-architecture.md`
+- `engineering-standards/data-model-design.md`
+- `engineering-standards/definition-of-done.md`
+
+### Domain knowledge
+
+Topical notes for the data domain live in `knowledge-base/topics/`. Some are still stubs (`glossary.md`, `gpc-framework.md` — open PRs welcome).
+
+---
+
+## Curated backlog for autonomous agents
+
+`docs/agent-runbook.md` is the authoritative list of tickets safe for an agentic run.
+
+---
+
+## Quickstart (humans)
+
+```bash
+# Postgres user/db
+createuser -s ccglobal && createdb -O ccglobal ccglobal
+
+# Local Mage stack
+cp dev.env .env       # ask the CTO if you need real secrets in io_config.yaml
+docker compose up     # http://localhost:6789
+```
+
+---
+
+## Questions / corrections
+
+If anything in this file or `.cursor/` is wrong, missing, or stale — **fix it in the same PR** that surfaced the gap. The agent contract only works if it's trustworthy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ When in doubt about which pattern a pipeline uses, **read the block code** — `
 - **Do not commit secrets.** AWS keys, DB passwords, `*.env`, `credentials*.json` → hard stop.
 - **Do not flip `production_approved: true`** without running the `definition-of-done-check` skill first.
 - **Do not introduce new deps** in `cc-mage/requirements.txt` without justification.
-- **Do not modify `AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, or `docs/agent-runbook.md` without CTO review.** These are the agentic + standards foundation; the CTO is the curator. (Product / pipeline code merges are unaffected — any tech-team member can merge as today.)
+- **Do not modify `AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`, `engineering-standards/`, or `docs/agent-runbook.md` without core-team review.** These are the agentic + standards foundation, curated by the core engineering team. (Product / pipeline code merges are unaffected — any tech-team member can merge as today.)
 
 ## What you must always do
 
@@ -134,7 +134,7 @@ Topical notes for the data domain live in `knowledge-base/topics/`. Some are sti
 createuser -s ccglobal && createdb -O ccglobal ccglobal
 
 # Local Mage stack
-cp dev.env .env       # ask the CTO if you need real secrets in io_config.yaml
+cp dev.env .env       # ask the team in #engineering for real secrets in io_config.yaml
 docker compose up     # http://localhost:6789
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ engineering-standards/    Team design principles and conventions
   data-quality-and-validation.md
   documentation-and-metadata.md
 
-domain-knowledge/         Shared domain definitions and reference materials
-  catalog/                Domain dataset catalog and metadata
+knowledge-base/           Shared domain definitions and reference materials
+  catalog/                Topic catalog and metadata
   collections/            Curated thematic groupings
   topics/                 Topic references and glossary pages
 
 ARCHITECTURE.md           Technical reference — data stages, DB schema, pipeline block flow
-AGENTS.md                 Agent guardrails and repository-specific constraints
+AGENTS.md                 Agent brief — read first
+.cursor/                  Cursor rules + skills (read by Cursor, agentic-coder, etc.)
+docs/agent-runbook.md     Curated tickets safe for autonomous agent runs
 docker-compose.yml        Local orchestration for Mage + dependencies
 dev.env                   Example local environment configuration
 ```
@@ -42,6 +44,8 @@ dev.env                   Example local environment configuration
 For the full technical architecture (S3 stages, database schema, Mage block structure) see [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
 For team conventions and design principles see [`engineering-standards/`](./engineering-standards/).
+
+For agent / AI usage (Cursor, agentic-coder, Cloud Agents) start with [`AGENTS.md`](./AGENTS.md).
 
 ---
 

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -15,7 +15,7 @@ The curated list of tasks an autonomous agent (Cursor agent, agentic-coder, Clou
 
 - [ ] **Update `README.md`** to reference `knowledge-base/` instead of `domain-knowledge/`. Skill: `docs-after-change`.
 - [ ] **Fix typo** in `knowledge-base/catalog/index.yaml`: `items/climate-projec.md` → `items/climate-project.md`.
-- [ ] **Fill stubbed knowledge-base topics** — `topics/glossary.md`, `topics/gpc-framework.md` are empty. Seed with 2–3 paragraphs each.
+- [ ] **Audit knowledge-base topics** — sweep `knowledge-base/topics/` for stale or thin pages, expand or cross-link as needed. Skill: `repo-doc-audit`.
 - [ ] **Audit `cc-mage/requirements.txt`** — list deps actually imported by blocks (boto3, requests, sqlalchemy) that aren't pinned. Add them with current versions.
 - [ ] **Fill `metadata.yaml.description`** for any pipeline where it is `null`. Skill: `mage-pipelines.mdc`.
 - [ ] **Add CI step** to fail on `metadata.yaml.description: null` (lint over `cc-mage/pipelines/**`).

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -1,0 +1,48 @@
+# Agent Runbook — global-data
+
+The curated list of tasks an autonomous agent (Cursor agent, agentic-coder, Cloud Agents) is allowed to pick up without further approval.
+
+> **Rules of the road**
+> - Pick the **top unchecked item** in the bucket that fits.
+> - Branch off `develop`. One ticket = one PR.
+> - Use the matching skill (linked).
+> - **Do not open the PR yourself unless explicitly told to.** Push the branch and stop.
+> - Cross items out as you ship.
+
+---
+
+## Quick (≤ 30 min, ≤ 5 files)
+
+- [ ] **Update `README.md`** to reference `knowledge-base/` instead of `domain-knowledge/`. Skill: `docs-after-change`.
+- [ ] **Fix typo** in `knowledge-base/catalog/index.yaml`: `items/climate-projec.md` → `items/climate-project.md`.
+- [ ] **Fill stubbed knowledge-base topics** — `topics/glossary.md`, `topics/gpc-framework.md` are empty. Seed with 2–3 paragraphs each.
+- [ ] **Audit `cc-mage/requirements.txt`** — list deps actually imported by blocks (boto3, requests, sqlalchemy) that aren't pinned. Add them with current versions.
+- [ ] **Fill `metadata.yaml.description`** for any pipeline where it is `null`. Skill: `mage-pipelines.mdc`.
+- [ ] **Add CI step** to fail on `metadata.yaml.description: null` (lint over `cc-mage/pipelines/**`).
+
+## Medium (≤ 2h, ≤ 20 files)
+
+- [ ] **Promote real Layer 2 tests** in 5 oldest pipelines. Replace `assert output is not None` with schema + uniqueness + plausibility checks. Rule: `mage-blocks-python.mdc`.
+- [ ] **Audit SQL exporters for UPSERT** — find any `data_exporter` with `export_write_policy: append` writing to `modelled.*` that is **not** an `INSERT … ON CONFLICT … DO UPDATE`. Skill: `sql-block-idempotency`.
+- [ ] **Add `created_at` / `updated_at` / `release_id`** to any `modelled.*` table missing them. See `engineering-standards/data-model-design.md` "backlog".
+- [ ] **Catalog hygiene** — for every dataset with `production_approved: true` whose `pipeline_name` or `data_quality` is null, fix or downgrade. Skill: `definition-of-done-check`.
+- [ ] **Fill `knowledge-base/collections/collection.yaml`** — current placeholders have no IDs. Wire to existing topics + datasets.
+
+## Large (half-day+)
+
+- [ ] **GitHub Actions: per-pipeline test job** — currently only `mage-ai-develop.yml` (Docker build). Add a CI job that runs Mage `@test` decorators against a sample for changed pipelines. Skill: `script-quality-gate`.
+- [ ] **`dq_*` pipelines** — one per `modelled.*` table doing post-write Layer 3 plausibility checks (negative values, gas codes in allowed set, year ranges). Skill: `scaffold-mage-pipeline`.
+- [ ] **Promote v2026 ClimateTRACE pipelines** — when CT publishes the new release, scaffold the `_v2026` fork and run the `definition-of-done-check`.
+
+## Continuous
+
+- [ ] **Run `repo-doc-audit`** monthly.
+- [ ] **Verify `production_approved` rows** weekly (script can be a `dq_catalog_health` pipeline).
+
+---
+
+## Adding tickets
+
+1. Write a 1-line description **+ matching skill**.
+2. Bucket Quick / Medium / Large by capability budget per agent run.
+3. Mention an existing branch if one exists.


### PR DESCRIPTION
## Summary

Establishes the agentic engineering foundation for `CityCatalyst-global-data`. Same shape (rules + skills + AGENTS.md + `.cursorignore`) is rolled out in parallel PRs in [`CityCatalyst` #2640](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2640) and [`agentic-coder` #1](https://github.com/Open-Earth-Foundation/agentic-coder/pull/1).

The intent: every agent (Cursor, Cursor Cloud Agent, `agentic-coder`, Claude Code, Codex) and every new human contributor gets the **same guardrails regardless of repo**.

## What lands here

- **`AGENTS.md`** rewritten as a 1-page read-first agent contract. Captures identity-key gotchas (`actor_id` vs `city_id`), critical constraints (don't rename `cc-mage/`, staging tables are temporary, etc.), and points at the deeper docs (`ARCHITECTURE.md`, `engineering-standards/`).
- **`.cursor/rules/`** — 11 rules:
  - `project-architecture`, `identity-keys`, `mage-pipelines`, `mage-blocks-python`, `mage-blocks-sql`, `dataset-review-catalog`, `python-style`, `git-conventions`, `security-baseline`, `os-shell`, `general`.
- **`.cursor/skills/`** — 13 named workflows:
  - Domain-specific: `add-publisher`, `add-dataset-release`, `scaffold-mage-pipeline`, `sql-block-idempotency`, `definition-of-done-check`.
  - Cross-repo: `repo-doc-audit`, `prompt-schema-authoring`, `pr-review-gate`, `pull-request-standards`, `commit-message-standards`, `docs-after-change`, `simplify-after-change`, `script-quality-gate`.
- **`docs/agent-runbook.md`** — curated tickets safe for autonomous agent runs (`agentic-coder`, Cursor Cloud Agent, etc.).
- **`.cursorignore`** — tuned for the repo (excludes large artifacts, secrets, lockfiles).
- **`README.md`** — adds an "Agent / AI usage" pointer.

## Cross-repo PRs

- [CityCatalyst #2640](https://github.com/Open-Earth-Foundation/CityCatalyst/pull/2640)
- **CityCatalyst-global-data — this PR**
- [agentic-coder #1](https://github.com/Open-Earth-Foundation/agentic-coder/pull/1)

## Test plan

- [ ] Open the repo in Cursor, confirm rules + skills are discovered (`@rule`, `@skill`)
- [ ] Run `agentic-coder` with `--profile global-data` against a runbook ticket; confirm context injection picks up `AGENTS.md`, `.cursor/rules/`, `.cursor/skills/`
- [ ] No secrets / large artifacts committed (`.cursorignore` review)
- [ ] `engineering-standards/` deep-links resolve from `AGENTS.md`

## Open questions for review

Specific MECE checks worth a second pair of eyes:

- `project-architecture` vs `mage-pipelines` — both touch repo layout / Mage stages. Are the boundaries crisp?
- `add-publisher` vs `add-dataset-release` — these are intentionally separate (one creates the publisher metadata, the other publishes a versioned dataset release), but the description copy could be sharper to make the trigger unambiguous.
- `simplify-after-change` vs `docs-after-change` — different purposes, similar names. Open to renames if there's a better axis.
- `pr-review-gate` vs `pull-request-standards` — `pull-request-standards` is "how to write a PR description for this repo"; `pr-review-gate` is "the checks an agent must pass before opening one". Want to validate that distinction reads cleanly.